### PR TITLE
Add Bootstrap_gh.sh script for GitHub CLI environment setup

### DIFF
--- a/scripts/Bootstrap_gh.sh
+++ b/scripts/Bootstrap_gh.sh
@@ -1,0 +1,1 @@
+Add bootstrap_gh.sh for Github CLI setup


### PR DESCRIPTION
This PR adds a new script `bootstrap_gh.sh` under /scripts that:

- Installs GitHub CLI if missing
- Authenticates user securely with GitHub CLI
- Clones the iOS-Tuxshell repository automatically
- Runs the Setup.sh script to initialize the environment

This allows new users to quickly bootstrap the entire TuxShell environment with a single command.

The script is compatible with iSH, Linux, and macOS terminal environments.

Once merged, this will be documented in README.md for easy onboarding.
---